### PR TITLE
Add flake for svix-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ or up-to-date in the main nixpkgs repository.
 - **Atlas 0.32.1** - Atlas CLI tool for database schema management, with support
   for both x86_64 and aarch64 architectures on Linux and macOS
 - **Cursor-cli** - [Cursor CLI tool](https://cursor.com/cli) (cluster-agent)
+- **Svix-server 1.76.1** - The enterprise-ready webhooks service, built from source
 
 ## Requirements
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1763966396,
+        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
             debezium-connector-mysql
             atlas
             debezium-server
+            svix-server
             ;
           debezium = customPkgs.debezium-connector-mysql; # Alias for compatibility
         };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4,4 +4,5 @@
   elasticsearch8 = import ./elasticsearch8.nix {inherit pkgs;};
   atlas = import ./atlas.nix {inherit pkgs;};
   debezium-server = import ./debezium-server.nix {inherit pkgs;};
+  svix-server = import ./svix-server.nix {inherit pkgs;};
 }

--- a/pkgs/svix-server.nix
+++ b/pkgs/svix-server.nix
@@ -1,0 +1,31 @@
+{pkgs}: let
+  version = "1.76.1";
+in
+  pkgs.rustPlatform.buildRustPackage rec {
+    pname = "svix-server";
+    inherit version;
+
+    src = pkgs.fetchFromGitHub {
+      owner = "svix";
+      repo = "svix-webhooks";
+      rev = "v${version}";
+      hash = "sha256-9ClWC/OHdijmQzKig/o6WhJ9mjlE6pLwvrRKzuO0l3g=";
+    };
+
+    sourceRoot = "${src.name}/server";
+
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-fOUPaU/1+FvL9hSzWQVouAXmCjI6ppOjJqtgM4+cXf8=";
+
+    # Skip tests during build (they require database setup)
+    doCheck = false;
+
+    meta = with pkgs.lib; {
+      description = "The enterprise-ready webhooks service";
+      homepage = "https://github.com/svix/svix-webhooks";
+      license = licenses.mit;
+      maintainers = [];
+      platforms = platforms.unix;
+    };
+  }
+

--- a/pkgs/svix-server.nix
+++ b/pkgs/svix-server.nix
@@ -14,8 +14,17 @@ in
 
     sourceRoot = "${src.name}/server";
 
-    useFetchCargoVendor = true;
     cargoHash = "sha256-fOUPaU/1+FvL9hSzWQVouAXmCjI6ppOjJqtgM4+cXf8=";
+
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+    ];
+
+    buildInputs = with pkgs; [
+      openssl
+    ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+      libiconv
+    ];
 
     # Skip tests during build (they require database setup)
     doCheck = false;


### PR DESCRIPTION
# Overview

The PR adds a flake for the svix-server v1.76.1 package. This is required be nixpkgs does not have
a distirbution built for aarch64-darwin or x86_64-darwin (fall back for rosetta I believe).

This flake builds the package from source.
