### PR TITLE
Add debezium-connector-planetscale package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             debezium-server
             svix-server
             terragrunt
+            debezium-connector-planetscale
             ;
           debezium = customPkgs.debezium-connector-mysql; # Alias for compatibility
         };

--- a/pkgs/debezium-connector-planetscale.nix
+++ b/pkgs/debezium-connector-planetscale.nix
@@ -1,0 +1,27 @@
+{pkgs}: let
+  version = "2.4.0.Final";
+  releaseTag = "v${version}.PS20241031.1";
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "debezium-connector-planetscale";
+    inherit version;
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/planetscale/debezium-connector-planetscale/releases/download/${releaseTag}/debezium-connector-planetscale-${version}-jar-with-dependencies.jar";
+      sha256 = "14ns02flqwc93rrjqxrlsw46zi6skbdf4cw83pj82jgrh6xrqwm2";
+    };
+
+    dontUnpack = true;
+
+    installPhase = ''
+      mkdir -p $out/debezium/debezium-connector-planetscale
+      cp $src $out/debezium/debezium-connector-planetscale/debezium-connector-planetscale-${version}-jar-with-dependencies.jar
+    '';
+
+    meta = with pkgs.lib; {
+      description = "PlanetScale-compatible Debezium CDC connector for Vitess/Kafka Connect";
+      homepage = "https://github.com/planetscale/debezium-connector-planetscale";
+      license = licenses.asl20;
+      platforms = platforms.unix;
+    };
+  }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,4 +6,6 @@
   debezium-server = import ./debezium-server.nix {inherit pkgs;};
   svix-server = import ./svix-server.nix {inherit pkgs;};
   terragrunt = import ./terragrunt.nix {inherit pkgs;};
+  debezium-connector-planetscale = import ./debezium-connector-planetscale.nix {inherit pkgs;};
+
 }


### PR DESCRIPTION
## Summary
- Adds `debezium-connector-planetscale` v2.4.0.Final as a Nix flake package
- Downloads the fat JAR (`jar-with-dependencies`) from the [PlanetScale fork](https://github.com/planetscale/debezium-connector-planetscale) of the Debezium Vitess connector
- Resolves merge conflicts with the recently added `terragrunt` package

## Test plan
- [x] `nix build .#debezium-connector-planetscale` succeeds
- [x] Output contains JAR at `$out/debezium/debezium-connector-planetscale/`
- [ ] Verify connector loads correctly with debezium-server via `EXTRA_CONNECTOR=planetscale`