### PR TITLE
Add debezium-connector-vitess v2.4.1.Final package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
             svix-server
             terragrunt
             debezium-connector-planetscale
+            debezium-connector-vitess
             ;
           debezium = customPkgs.debezium-connector-mysql; # Alias for compatibility
         };

--- a/pkgs/debezium-connector-vitess.nix
+++ b/pkgs/debezium-connector-vitess.nix
@@ -1,0 +1,14 @@
+{pkgs}:
+pkgs.stdenv.mkDerivation {
+  name = "debezium-connector-vitess";
+  src = (
+    fetchTarball {
+      url = "https://repo1.maven.org/maven2/io/debezium/debezium-connector-vitess/2.4.1.Final/debezium-connector-vitess-2.4.1.Final-plugin.tar.gz";
+      sha256 = "1zjjrgg3fyprym377maz40xl9pv1h8mgsfhc5alqm6v8xx0ilp72";
+    }
+  );
+  installPhase = ''
+    mkdir -p $out/debezium/debezium-connector-vitess
+    cp -R . $out/debezium/debezium-connector-vitess
+  '';
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -7,5 +7,6 @@
   svix-server = import ./svix-server.nix {inherit pkgs;};
   terragrunt = import ./terragrunt.nix {inherit pkgs;};
   debezium-connector-planetscale = import ./debezium-connector-planetscale.nix {inherit pkgs;};
+  debezium-connector-vitess = import ./debezium-connector-vitess.nix {inherit pkgs;};
 
 }


### PR DESCRIPTION
## Summary
- Add `debezium-connector-vitess` v2.4.1.Final package from Maven Central
- Register in `pkgs/default.nix` and expose in `flake.nix`

## Test plan
- [x] `nix build .#debezium-connector-vitess` succeeds
- [x] Output contains expected JAR files under `debezium/debezium-connector-vitess/`