### PR TITLE
Add vitess 21.0.4 package with config/ directory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
             terragrunt
             debezium-connector-planetscale
             debezium-connector-vitess
+            vitess
             ;
           debezium = customPkgs.debezium-connector-mysql; # Alias for compatibility
         };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,6 @@
 {pkgs}: {
+  vitess = import ./vitess.nix {inherit pkgs;};
+
   debezium-connector-mysql = import ./debezium-connector-mysql.nix {inherit pkgs;};
   cursor-cli = import ./cursor-cli.nix {inherit pkgs;};
   elasticsearch8 = import ./elasticsearch8.nix {inherit pkgs;};

--- a/pkgs/vitess.nix
+++ b/pkgs/vitess.nix
@@ -1,0 +1,37 @@
+# Builds vitess 21.0.4 with the config/ directory included.
+#
+# The upstream nixpkgs vitess package only ships bin/, but vttestserver/mysqlctl
+# expect $VTROOT/config/init_db.sql and $VTROOT/config/mycnf/*.cnf at runtime.
+{pkgs}:
+pkgs.buildGoModule (finalAttrs: {
+  pname = "vitess";
+  version = "21.0.4";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "vitessio";
+    repo = "vitess";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-QapbbLZ/wDCKYQW98l780PT4ZEXAbhW0o4Zk2MlG6DQ=";
+  };
+
+  vendorHash = "sha256-Bc9rhfGSjqhDQBOPS4noW8qJ4P5xLtVcokRhDbqP3a0=";
+
+  buildInputs = [pkgs.sqlite];
+
+  subPackages = ["go/cmd/..."];
+
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/config/mycnf
+    cp $src/config/init_db.sql $out/config/
+    cp $src/config/mycnf/*.cnf $out/config/mycnf/
+  '';
+
+  meta = {
+    homepage = "https://vitess.io/";
+    changelog = "https://github.com/vitessio/vitess/releases/tag/v${finalAttrs.version}";
+    description = "Database clustering system for horizontal scaling of MySQL";
+    license = pkgs.lib.licenses.asl20;
+  };
+})


### PR DESCRIPTION
## Summary
- Adds a `vitess` package that builds vitess 21.0.4 from source
- Includes the `config/` directory (init_db.sql, mycnf/*.cnf) in the package output, which the upstream nixpkgs package omits
- `vttestserver` and `mysqlctl` require these config files at `$VTROOT/config/` at runtime

## Context
Setting up Vitess for local development in the root orchestrator project. The nixpkgs vitess derivation only ships `bin/`, causing `vttestserver` to fail with `can't open init_db_sql_file`. This package fixes that by copying config files from the source tree into the nix store output.

## Test plan
- [x] `nix build .#vitess` succeeds
- [x] Output contains `bin/` with all vitess binaries
- [x] Output contains `config/init_db.sql` and `config/mycnf/*.cnf`
- [x] `vttestserver --version` reports 21.0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)