### PR TITLE
Add rustfs 1.0.0-alpha.82 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ or up-to-date in the main nixpkgs repository.
   for both x86_64 and aarch64 architectures on Linux and macOS
 - **Cursor-cli** - [Cursor CLI tool](https://cursor.com/cli) (cluster-agent)
 - **Svix-server 1.76.1** - The enterprise-ready webhooks service, built from source
+- **RustFS 1.0.0-alpha.82** - High-performance S3-compatible object storage, built from source
 
 ## Requirements
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
             debezium-connector-planetscale
             debezium-connector-vitess
             vitess
+            rustfs
             ;
           debezium = customPkgs.debezium-connector-mysql; # Alias for compatibility
         };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -10,5 +10,6 @@
   terragrunt = import ./terragrunt.nix {inherit pkgs;};
   debezium-connector-planetscale = import ./debezium-connector-planetscale.nix {inherit pkgs;};
   debezium-connector-vitess = import ./debezium-connector-vitess.nix {inherit pkgs;};
+  rustfs = import ./rustfs.nix {inherit pkgs;};
 
 }

--- a/pkgs/rustfs.nix
+++ b/pkgs/rustfs.nix
@@ -1,0 +1,46 @@
+{pkgs}:
+let
+  version = "1.0.0-alpha.82";
+in
+  pkgs.rustPlatform.buildRustPackage rec {
+    pname = "rustfs";
+    inherit version;
+
+    src = pkgs.fetchFromGitHub {
+      owner = "rustfs";
+      repo = "rustfs";
+      rev = version;
+      hash = "sha256-wkqGGzCnAJk8HGIQ4iB0P0SQptrRtWATz2DdE5CpBMo=";
+    };
+
+    cargoHash = "sha256-wvc7qpIbh5asE89gvMr+Ga/3dbqfthxCrZHPvO0/mU0=";
+
+    cargoBuildFlags = ["-p" "rustfs"];
+
+    env = {
+      RUSTFLAGS = "--cfg tokio_unstable";
+      PROTOC = "${pkgs.protobuf}/bin/protoc";
+    };
+
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+      protobuf
+    ];
+
+    buildInputs = with pkgs; [
+      openssl
+    ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+      libiconv
+    ];
+
+    # Skip tests during build (they require infrastructure setup)
+    doCheck = false;
+
+    meta = with pkgs.lib; {
+      description = "High-performance S3-compatible object storage";
+      homepage = "https://github.com/rustfs/rustfs";
+      license = licenses.asl20;
+      maintainers = [];
+      platforms = platforms.unix;
+    };
+  }


### PR DESCRIPTION
## Summary
- Add rustfs (S3-compatible object storage) as a new Nix package built from source
- Pinned to alpha.82 to stay compatible with the current nixpkgs Rust 1.92.0 (alpha.83+ requires 1.93.0)
- Registered in default.nix, exported in flake.nix, documented in README

## Test plan
- [x] `nix build .#rustfs` succeeds locally (aarch64-darwin)
- [x] `nix run .#rustfs -- --version` outputs version info
- [x] CI `nix flake check` passes