### PR TITLE
Upgrade vitess from 21.0.4 to 23.0.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {

--- a/pkgs/vitess.nix
+++ b/pkgs/vitess.nix
@@ -1,20 +1,20 @@
-# Builds vitess 21.0.4 with the config/ directory included.
+# Builds vitess 23.0.3 with the config/ directory included.
 #
 # The upstream nixpkgs vitess package only ships bin/, but vttestserver/mysqlctl
 # expect $VTROOT/config/init_db.sql and $VTROOT/config/mycnf/*.cnf at runtime.
 {pkgs}:
 pkgs.buildGoModule (finalAttrs: {
   pname = "vitess";
-  version = "21.0.4";
+  version = "23.0.3";
 
   src = pkgs.fetchFromGitHub {
     owner = "vitessio";
     repo = "vitess";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-QapbbLZ/wDCKYQW98l780PT4ZEXAbhW0o4Zk2MlG6DQ=";
+    hash = "sha256-cLpVpdYpMzJX5Y4RBuUp2SbedBHiqG+SRu8Oh+dowFY=";
   };
 
-  vendorHash = "sha256-Bc9rhfGSjqhDQBOPS4noW8qJ4P5xLtVcokRhDbqP3a0=";
+  vendorHash = "sha256-YhWa5eUeMCqmA+8Mi3lxQTSQ29xMpWWAb2BQPN1/+N8=";
 
   buildInputs = [pkgs.sqlite];
 


### PR DESCRIPTION
## Summary
- Upgrades vitess from v21.0.4 to v23.0.3
- Updates nixpkgs input to pick up Go 1.26.1 (vitess v23 requires Go >= 1.25.7)
- Build verified: all binaries and config/ files present

## Test plan
- [x] `nix build .#vitess` succeeds
- [x] Output contains expected binaries (`vtgate`, `vttablet`, `mysqlctl`, etc.)
- [x] `config/init_db.sql` and `config/mycnf/*.cnf` are present in the output