### PR TITLE
chore(atlas): upgrade canary 0.32.1 to stable v1.2.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
 
           atlas-version = pkgs.runCommand "check-atlas-version" {} ''
             output=$(${customPkgs.atlas}/bin/atlas version)
-            expected_version="0.32.1"
+            expected_version="1.2.0"
 
             if echo "$output" | grep -q "$expected_version"; then
               echo "✓ Atlas version check passed: $output"

--- a/pkgs/atlas.nix
+++ b/pkgs/atlas.nix
@@ -10,14 +10,13 @@
     then "darwin"
     else "linux";
 
-  version = "0.32.1-d9ffec1-canary";
+  version = "1.2.0";
 
   hashes = {
-    "amd64-linux" = "sha256-SgQy/Ht3PtSqqozZvJHlQKbydYX9r0ZQczCu8OQCV7M=";
-    "arm64-linux" = "sha256-SgQy/Ht3PtSqqozZvJHlQKbydYX9r0ZQczCu8OQCV7M=";
-    "amd64-darwin" = "sha256-9sse774dV4aLKMCvKGH6vJyguldsKPnhVN4KofywTMY=";
-    "arm64-darwin" = "sha256-9sse774dV4aLKMCvKGH6vJyguldsKPnhVN4KofywTMY=";
-    # Add other platform hashes as needed
+    "amd64-linux" = "sha256-H9CQIf+hNXWUUF9EL5eDz8JZn6Wgq4UMWWLtbXe/nJo=";
+    "arm64-linux" = "sha256-w3Xe5jnW1CllWJ7yhcFJ0XZJ+uEojIrBh4AUNWYfNUM=";
+    "amd64-darwin" = "sha256-Nr2+Y7vCint0Anve/dUOwu8zrMYeo+H845s0He+NuOM=";
+    "arm64-darwin" = "sha256-IFCP33rXl4neLUU68Lt3PiWCrLXJmV2hnhGel+yTb+E=";
   };
 in
   pkgs.stdenv.mkDerivation rec {


### PR DESCRIPTION
## Summary
- Upgrade `atlas` from canary 0.32.1 to stable v1.2.0.

## Test plan
- [ ] `nix build .#atlas` succeeds on darwin and linux.
- [ ] `atlas version` reports v1.2.0.