### PR TITLE
chore(nix): add Alejandra formatter checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,8 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
+      - name: Check formatting
+        run: nix fmt flake.nix pkgs/*.nix -- --check
+
       - name: Run nix flake check
         run: nix flake check

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,8 @@
         # Import our package modules
         customPkgs = import ./pkgs {inherit pkgs;};
       in {
+        formatter = pkgs.alejandra;
+
         packages = {
           inherit
             (customPkgs)

--- a/pkgs/cursor-cli.nix
+++ b/pkgs/cursor-cli.nix
@@ -7,7 +7,7 @@ pkgs.stdenv.mkDerivation {
     pkgs.cacert
     pkgs.bash
     pkgs.curl
-    ];
+  ];
   src = pkgs.fetchurl {
     url = "https://cursor.com/install";
     sha256 = "sha256-MGfKxi3R+PpSQk8rB4CBL7Iw63G+U+5sk0g2+5OcsnM="; # You'll need to get the actual hash

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -11,5 +11,4 @@
   debezium-connector-planetscale = import ./debezium-connector-planetscale.nix {inherit pkgs;};
   debezium-connector-vitess = import ./debezium-connector-vitess.nix {inherit pkgs;};
   rustfs = import ./rustfs.nix {inherit pkgs;};
-
 }

--- a/pkgs/elasticsearch8.nix
+++ b/pkgs/elasticsearch8.nix
@@ -34,11 +34,13 @@ in
         "ES_CLASSPATH=\"\$ES_CLASSPATH:$out/\$additional_classpath_directory/*\""
     '';
 
-    nativeBuildInputs = [
-      pkgs.makeBinaryWrapper
-    ] ++ pkgs.lib.optionals (!pkgs.stdenv.hostPlatform.isDarwin) [
-      pkgs.patchelf
-    ];
+    nativeBuildInputs =
+      [
+        pkgs.makeBinaryWrapper
+      ]
+      ++ pkgs.lib.optionals (!pkgs.stdenv.hostPlatform.isDarwin) [
+        pkgs.patchelf
+      ];
 
     buildInputs = [
       pkgs.jre_headless
@@ -79,7 +81,7 @@ in
           fi
           if ${pkgs.patchelf}/bin/patchelf --print-rpath "$file" 2>/dev/null; then
             ${pkgs.patchelf}/bin/patchelf \
-              --set-rpath "${pkgs.lib.makeLibraryPath [ pkgs.zlib pkgs.stdenv.cc.cc.lib ]}" \
+              --set-rpath "${pkgs.lib.makeLibraryPath [pkgs.zlib pkgs.stdenv.cc.cc.lib]}" \
               "$file" 2>/dev/null || echo "Failed to set rpath for $file"
           fi
         fi
@@ -90,7 +92,7 @@ in
         if file "$file" | grep -q "ELF.*shared object" && [ ! -L "$file" ]; then
           echo "Patching shared library: $file"
           ${pkgs.patchelf}/bin/patchelf \
-            --set-rpath "${pkgs.lib.makeLibraryPath [ pkgs.zlib pkgs.stdenv.cc.cc.lib ]}" \
+            --set-rpath "${pkgs.lib.makeLibraryPath [pkgs.zlib pkgs.stdenv.cc.cc.lib]}" \
             "$file" 2>/dev/null || echo "Failed to patch shared library $file"
         fi
       done

--- a/pkgs/rustfs.nix
+++ b/pkgs/rustfs.nix
@@ -1,5 +1,4 @@
-{pkgs}:
-let
+{pkgs}: let
   version = "1.0.0-alpha.96";
 in
   pkgs.rustPlatform.buildRustPackage rec {
@@ -27,11 +26,13 @@ in
       protobuf
     ];
 
-    buildInputs = with pkgs; [
-      openssl
-    ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
-      libiconv
-    ];
+    buildInputs = with pkgs;
+      [
+        openssl
+      ]
+      ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+        libiconv
+      ];
 
     # Skip tests during build (they require infrastructure setup)
     doCheck = false;

--- a/pkgs/svix-server.nix
+++ b/pkgs/svix-server.nix
@@ -20,11 +20,13 @@ in
       pkg-config
     ];
 
-    buildInputs = with pkgs; [
-      openssl
-    ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
-      libiconv
-    ];
+    buildInputs = with pkgs;
+      [
+        openssl
+      ]
+      ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+        libiconv
+      ];
 
     # Skip tests during build (they require database setup)
     doCheck = false;
@@ -37,4 +39,3 @@ in
       platforms = platforms.unix;
     };
   }
-


### PR DESCRIPTION
## Summary
- Add Alejandra formatter checks to CI and reformat Nix files in the tree.

## Test plan
- [ ] CI `alejandra --check` step passes.
- [ ] `nix flake check` succeeds.